### PR TITLE
Increase flexibility of DDRX2 module.

### DIFF
--- a/litehyperbus/core/hyperram_ddrx2.py
+++ b/litehyperbus/core/hyperram_ddrx2.py
@@ -34,7 +34,7 @@ class HyperRAMX2(Module):
      - Handle variable latency writes
      - Add Litex automated tests
     """
-    def __init__(self, pads):
+    def __init__(self, pads, latency = 6):
         self.pads = pads
         self.bus  = bus = wishbone.Interface(adr_width=22)
 
@@ -114,7 +114,7 @@ class HyperRAMX2(Module):
             NextValue(phy.dq.oe, 0),
             NextState("LATENCY-WAIT")
         )
-        fsm.delayed_enter("LATENCY-WAIT", "READ-WRITE-SETUP", 3)
+        fsm.delayed_enter("LATENCY-WAIT", "READ-WRITE-SETUP", latency - 3)
         fsm.act("READ-WRITE-SETUP",
             NextValue(phy.dq.oe, self.bus.we),
             NextValue(phy.rwds.oe,self.bus.we),

--- a/litehyperbus/phy/ecp5phy_ddrx2.py
+++ b/litehyperbus/phy/ecp5phy_ddrx2.py
@@ -60,51 +60,76 @@ class HyperBusPHY(Module):
         self.comb += clk_en.eq(self.clk_enable & ~self.cs)
 
         # Clk_out
-        clkp = Signal()
-        clkn = Signal()
-        self.specials += [
-            Instance("ODDRX2F",
-                i_SCLK = ClockSignal("hr_90"),
-                i_ECLK = ClockSignal("hr2x_90"),
-                i_RST  = ResetSignal("hr"),
-                i_D3   = clk_en,
-                i_D2   = 0,
-                i_D1   = clk_en,
-                i_D0   = 0,
-                o_Q    = clkp
-            ),
-            Instance("DELAYF",
-                p_DEL_MODE  = "USER_DEFINED",
-                p_DEL_VALUE = 0, # (25ps per tap)
-                i_A         = clkp,
-                i_LOADN     = self.dly_clk.loadn,
-                i_MOVE      = self.dly_clk.move,
-                i_DIRECTION = self.dly_clk.direction,
-                o_Z         = pads.clk_p
-            )
-        ]
+        if hasattr(pads, "clk"):
+            clk = Signal()
+            self.specials += [
+                Instance("ODDRX2F",
+                    i_SCLK = ClockSignal("hr_90"),
+                    i_ECLK = ClockSignal("hr2x_90"),
+                    i_RST  = ResetSignal("hr"),
+                    i_D3   = clk_en,
+                    i_D2   = 0,
+                    i_D1   = clk_en,
+                    i_D0   = 0,
+                    o_Q    = clk
+                ),
+                Instance("DELAYF",
+                    p_DEL_MODE  = "USER_DEFINED",
+                    p_DEL_VALUE = 0, # (25ps per tap)
+                    i_A         = clk,
+                    i_LOADN     = self.dly_clk.loadn,
+                    i_MOVE      = self.dly_clk.move,
+                    i_DIRECTION = self.dly_clk.direction,
+                    o_Z         = pads.clk
+                )
+            ]
 
-        self.specials += [
-            Instance("ODDRX2F",
-                i_SCLK = ClockSignal("hr_90"),
-                i_ECLK = ClockSignal("hr2x_90"),
-                i_RST  = ResetSignal("hr"),
-                i_D3   = ~clk_en,
-                i_D2   = 1,
-                i_D1   = ~clk_en,
-                i_D0   = 1,
-                o_Q    = clkn
-            ),
-            Instance("DELAYF",
-                p_DEL_MODE  = "USER_DEFINED",
-                p_DEL_VALUE = 0, # (25ps per tap)
-                i_A         = clkn,
-                i_LOADN     = self.dly_clk.loadn,
-                i_MOVE      = self.dly_clk.move,
-                i_DIRECTION = self.dly_clk.direction,
-                o_Z         = pads.clk_n
-            )
-        ]
+        else:
+            clkp = Signal()
+            clkn = Signal()
+            self.specials += [
+                Instance("ODDRX2F",
+                    i_SCLK = ClockSignal("hr_90"),
+                    i_ECLK = ClockSignal("hr2x_90"),
+                    i_RST  = ResetSignal("hr"),
+                    i_D3   = clk_en,
+                    i_D2   = 0,
+                    i_D1   = clk_en,
+                    i_D0   = 0,
+                    o_Q    = clkp
+                ),
+                Instance("DELAYF",
+                    p_DEL_MODE  = "USER_DEFINED",
+                    p_DEL_VALUE = 0, # (25ps per tap)
+                    i_A         = clkp,
+                    i_LOADN     = self.dly_clk.loadn,
+                    i_MOVE      = self.dly_clk.move,
+                    i_DIRECTION = self.dly_clk.direction,
+                    o_Z         = pads.clk_p
+                )
+            ]
+
+            self.specials += [
+                Instance("ODDRX2F",
+                    i_SCLK = ClockSignal("hr_90"),
+                    i_ECLK = ClockSignal("hr2x_90"),
+                    i_RST  = ResetSignal("hr"),
+                    i_D3   = ~clk_en,
+                    i_D2   = 1,
+                    i_D1   = ~clk_en,
+                    i_D0   = 1,
+                    o_Q    = clkn
+                ),
+                Instance("DELAYF",
+                    p_DEL_MODE  = "USER_DEFINED",
+                    p_DEL_VALUE = 0, # (25ps per tap)
+                    i_A         = clkn,
+                    i_LOADN     = self.dly_clk.loadn,
+                    i_MOVE      = self.dly_clk.move,
+                    i_DIRECTION = self.dly_clk.direction,
+                    o_Z         = pads.clk_n
+                )
+            ]
 
         # DQ_out
         for i in range(8):


### PR DESCRIPTION
This is two minor fixes to make the DDRX2 module work with my board.

The first patch adds support for having a single ended clock.

The second patch makes latency configurable. While many parts defaults to 6 like the code assumes, the W956A8MBYA5I that I've got expects 7 by default.